### PR TITLE
Use of PlanetsLib to define planets

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,24 +1,25 @@
 {
-  "name": "maraxsis",
-  "title": "Maraxsis",
-  "description": "Dive into the uncharted waters of Maraxsis, a world where the sea covers everything. Utilize submarines to explore, craft advanced fluids inside the hydro plant, build pressure domes, and master the challenges of deep-sea logistics.",
-  "author": "notnotmelon",
-  "homepage": "https://github.com/notnotmelon/maraxsis",
-  "version": "1.27.14",
-  "factorio_version": "2.0",
-  "dependencies": [
-    "base >= 2.0.26",
-    "space-age >= 2.0.26",
-    "SpidertronPatrols >= 2.5.5",
-    "FluidMustFlow >= 1.4.2",
-    "(?) tenebris",
-    "(?) SchallTransportGroup",
-    "! Land-Pump"
-  ],
-  "quality_required": true,
-  "space_travel_required": true,
-  "spoiling_required": true,
-  "freezing_required": true,
-  "segmented_units_required": true,
-  "expansion_shaders_required": true
+    "name": "maraxsis",
+    "title": "Maraxsis",
+    "description": "Dive into the uncharted waters of Maraxsis, a world where the sea covers everything. Utilize submarines to explore, craft advanced fluids inside the hydro plant, build pressure domes, and master the challenges of deep-sea logistics.",
+    "author": "notnotmelon",
+    "homepage": "https://github.com/notnotmelon/maraxsis",
+    "version": "1.27.14",
+    "factorio_version": "2.0",
+    "dependencies": [
+        "base >= 2.0.26",
+        "space-age >= 2.0.26",
+        "SpidertronPatrols >= 2.5.5",
+        "FluidMustFlow >= 1.4.2",
+        "PlanetsLib >= 1.1.11",
+        "(?) tenebris",
+        "(?) SchallTransportGroup",
+        "! Land-Pump"
+    ],
+    "quality_required": true,
+    "space_travel_required": true,
+    "spoiling_required": true,
+    "freezing_required": true,
+    "segmented_units_required": true,
+    "expansion_shaders_required": true
 }

--- a/prototypes/planet/space-location.lua
+++ b/prototypes/planet/space-location.lua
@@ -1,10 +1,10 @@
-require "maraxsis-noise-expressions"
-require "trench-noise-expressions"
+require("maraxsis-noise-expressions")
+require("trench-noise-expressions")
 
-local asteroid_util = require "__space-age__.prototypes.planet.asteroid-spawn-definitions"
-local planet_map_gen = require "map-gen"
+local asteroid_util = require("__space-age__.prototypes.planet.asteroid-spawn-definitions")
+local planet_map_gen = require("map-gen")
 
-data:extend {maraxsis.merge(data.raw.planet.gleba, {
+local planet = maraxsis.merge(data.raw.planet.gleba, {
     name = "maraxsis",
     starting_area = 1,
     surface_properties = {
@@ -13,6 +13,14 @@ data:extend {maraxsis.merge(data.raw.planet.gleba, {
         ["solar-power"] = 100,
         pressure = 200000,
         gravity = 20,
+    },
+    orbit = {
+        parent = {
+            name = "star",
+            type = "space-location",
+        },
+        distance = 15,
+        orientation = 0.515,
     },
     starmap_icon = "__maraxsis__/graphics/planets/maraxsis-starmap-icon.png",
     starmap_icon_size = 512,
@@ -23,13 +31,17 @@ data:extend {maraxsis.merge(data.raw.planet.gleba, {
     solar_power_in_space = 150,
     player_effects = "nil",
     map_gen_settings = planet_map_gen.maraxsis(),
-    distance = 15,
     draw_orbit = false,
-    orientation = 0.515,
     flying_robot_energy_usage_multiplier = 1.5, -- todo: this doesnt work
-})}
+})
+planet.distance = nil
+planet.orientation = nil
 
-data:extend {maraxsis.merge(data.raw.planet.gleba, {
+PlanetsLib:extend({
+	planet,
+})
+
+local trench = maraxsis.merge(data.raw.planet.gleba, {
     name = "maraxsis-trench",
     starting_area = 1,
     surface_properties = {
@@ -39,6 +51,14 @@ data:extend {maraxsis.merge(data.raw.planet.gleba, {
         pressure = 400000,
         gravity = 20,
     },
+    orbit = {
+        parent = {
+            name = "maraxsis",
+            type = "planet",
+        },
+        distance = 0.6,
+        orientation = 0.25,
+    },
     hidden = true,
     icon = "__maraxsis__/graphics/technology/maraxsis-trench.png",
     icon_size = 256,
@@ -47,62 +67,72 @@ data:extend {maraxsis.merge(data.raw.planet.gleba, {
     draw_orbit = false,
     solar_power_in_space = 150,
     map_gen_settings = planet_map_gen["maraxsis-trench"](),
-    distance = 15.6,
     label_orientation = 0.3,
     magnitude = 0.65,
     player_effects = "nil",
-    orientation = 0.5,
     auto_save_on_first_trip = false,
     asteroid_spawn_definitions = "nil",
     flying_robot_energy_usage_multiplier = 1.5, -- todo: this doesnt work
-})}
+})
+trench.distance = nil
+trench.orientation = nil
+
+PlanetsLib:extend({
+	trench,
+})
 
 data.raw.planet["maraxsis-trench"].persistent_ambient_sounds.wind = {
-    sound = {
-        filename = "__maraxsis__/sounds/trench-ambiance.ogg",
-        volume = 0.8
-    },
+	sound = {
+		filename = "__maraxsis__/sounds/trench-ambiance.ogg",
+		volume = 0.8,
+	},
 }
 
 data.raw.planet["maraxsis"].persistent_ambient_sounds.wind = {
-    sound = {
-        filename = "__maraxsis__/sounds/maraxsis-ambiance.ogg",
-        volume = 0.8,
-        speed = 0.5
-    },
+	sound = {
+		filename = "__maraxsis__/sounds/maraxsis-ambiance.ogg",
+		volume = 0.8,
+		speed = 0.5,
+	},
 }
 
-data:extend {{
-    type = "space-connection",
-    name = "vulcanus-maraxsis",
-    subgroup = "planet-connections",
-    from = "vulcanus",
-    to = "maraxsis",
-    order = "f",
-    length = 20000,
-    asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo)
-}}
+data:extend({
+	{
+		type = "space-connection",
+		name = "vulcanus-maraxsis",
+		subgroup = "planet-connections",
+		from = "vulcanus",
+		to = "maraxsis",
+		order = "f",
+		length = 20000,
+		asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo),
+	},
+})
 
-data:extend {{
-    type = "space-connection",
-    name = "fulgora-maraxsis",
-    subgroup = "planet-connections",
-    from = "fulgora",
-    to = "maraxsis",
-    order = "f",
-    length = 20000,
-    asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo)
-}}
+data:extend({
+	{
+		type = "space-connection",
+		name = "fulgora-maraxsis",
+		subgroup = "planet-connections",
+		from = "fulgora",
+		to = "maraxsis",
+		order = "f",
+		length = 20000,
+		asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo),
+	},
+})
 
 if mods.tenebris then
-    data:extend {{
-        type = "space-connection",
-        name = "maraxsis-tenebris",
-        subgroup = "planet-connections",
-        from = "maraxsis",
-        to = "tenebris",
-        order = "g",
-        length = 20000,
-        asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo)
-    }}
+	data:extend({
+		{
+			type = "space-connection",
+			name = "maraxsis-tenebris",
+			subgroup = "planet-connections",
+			from = "maraxsis",
+			to = "tenebris",
+			order = "g",
+			length = 20000,
+			asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo),
+		},
+	})
 end


### PR DESCRIPTION
If you would at some point like to use PlanetsLib as a dependency, this PR adjusts the definition of the prototypes `maraxsis` and `maraxsis-trench` to use the PlanetsLib helper.