### PR TITLE
compat: Added compatibility with modules-t4

### DIFF
--- a/compat/modules-t4.lua
+++ b/compat/modules-t4.lua
@@ -1,0 +1,13 @@
+if mods["modules-t4"] then
+    table.insert(data.raw["technology"]["quality-module-4"].prerequisites,
+    "hydraulic-science-pack"
+    )
+    table.insert(data.raw["technology"]["quality-module-4"].unit.ingredients,
+    {"hydraulic-science-pack",1}
+    )
+    data.raw["recipe"]["quality-module-4"].ingredients = {
+        {type = "item", name = "maraxsis-salt", amount = 1},
+        {type = "item", name = "quantum-processor", amount = 5},
+        {type = "item", name = "quality-module-3", amount = 5},
+    }
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -11,6 +11,7 @@ require "compat.aai-signal-transmission"
 require "compat.editor-extensions"
 require "compat.transport-ring-teleporter"
 require "compat.quality-seeds"
+require "compat.modules-t4"
 
 local function add_fuel_value(fluid, value)
     fluid = data.raw.fluid[fluid]

--- a/info.json
+++ b/info.json
@@ -13,7 +13,8 @@
     "FluidMustFlow >= 1.4.2",
     "(?) tenebris",
     "(?) SchallTransportGroup",
-    "! Land-Pump"
+    "! Land-Pump",
+    "? modules-t4"
   ],
   "quality_required": true,
   "space_travel_required": true,


### PR DESCRIPTION
Adds optional compatibility with the mod "modules-t4", giving it a new recipe that requires Maraxsis salt.

This is part of an idea that I hope comes to fruition at some point, where four modded planets each reserve one module type for themselves, and add a recipe for a tier 4 module using resources from their planet.

![Screenshot from 2025-01-19 22-03-35](https://github.com/user-attachments/assets/23429038-70dc-4499-879f-3f81ca462fdc)
![Screenshot from 2025-01-19 22-03-41](https://github.com/user-attachments/assets/e81a37c2-053d-45fc-9ec8-454de235180f)
