### PR TITLE
compat: Added compatibility with Tenebris-prime.

### DIFF
--- a/info.json
+++ b/info.json
@@ -12,6 +12,7 @@
     "SpidertronPatrols >= 2.5.5",
     "FluidMustFlow >= 1.4.2",
     "(?) tenebris",
+    "(?) tenebris-prime",
     "(?) SchallTransportGroup",
     "! Land-Pump",
     "! no-more-gambling",

--- a/prototypes/planet/space-location.lua
+++ b/prototypes/planet/space-location.lua
@@ -94,7 +94,7 @@ data:extend {{
     asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo)
 }}
 
-if mods.tenebris then
+if data.raw["planet"]["tenebris"] then
     data:extend {{
         type = "space-connection",
         name = "maraxsis-tenebris",
@@ -106,3 +106,4 @@ if mods.tenebris then
         asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.gleba_aquilo)
     }}
 end
+


### PR DESCRIPTION
This changes the space connection between Maraxsis and Tenebris to check for a planet named "Tenebris" instead of checking if the mod "Tenebris" is installed. This is to ensure that this connection is created for all forks of Tenebris.