### PR TITLE
Fix typo

### DIFF
--- a/prototypes/entity/pressure-dome.lua
+++ b/prototypes/entity/pressure-dome.lua
@@ -103,7 +103,7 @@ data:extend {{
         volume = 0
     },
     created_smoke = {
-        type = "create-trival-smoke",
+        type = "create-trivial-smoke",
         smoke_name = "maraxsis-invisible-smoke",
     },
 }}


### PR DESCRIPTION
Conform to https://lua-api.factorio.com/stable/types/CreateTrivialSmokeEffectItem.html#type.

I'm not the typo police :) I was using your mod to test my https://github.com/jacquev6/factorio-data-raw-json-schema/ and discovered this typo, so I figured I might as well tell you.

Thanks!