### PR TITLE
Compatibility with call-plumber

### DIFF
--- a/compat/call-plumber.lua
+++ b/compat/call-plumber.lua
@@ -1,5 +1,7 @@
 
-if script.active_mods["call-plumber"] then
+-- This file runs in the control stage
+
+if not script.active_mods["call-plumber"] then return end
 
 maraxsis.on_event(maraxsis.events.on_init(), function()
     -- Most fluids are compatible with normal pipes
@@ -17,4 +19,3 @@ maraxsis.on_event(maraxsis.events.on_init(), function()
     )
 end)
 
-end  -- call-plumber

--- a/control.lua
+++ b/control.lua
@@ -18,6 +18,6 @@ require "scripts.trench-duct"
 require "scripts.abyssal-diving-gear"
 require "scripts.remote"
 require "scripts.fishing-tower"
-require "scripts.mod-compatibility"
+require "compat.call-plumber"
 
 maraxsis.finalize_events()

--- a/control.lua
+++ b/control.lua
@@ -18,5 +18,6 @@ require "scripts.trench-duct"
 require "scripts.abyssal-diving-gear"
 require "scripts.remote"
 require "scripts.fishing-tower"
+require "scripts.mod-compatibility"
 
 maraxsis.finalize_events()

--- a/info.json
+++ b/info.json
@@ -16,7 +16,8 @@
     "(?) SchallTransportGroup",
     "! Land-Pump",
     "! no-more-gambling",
-    "? modules-t4"
+    "? modules-t4",
+    "? call-plumber >= 1.0.0"
   ],
   "quality_required": true,
   "space_travel_required": true,

--- a/scripts/mod-compatibility.lua
+++ b/scripts/mod-compatibility.lua
@@ -1,0 +1,20 @@
+
+if script.active_mods["call-plumber"] then
+
+maraxsis.on_event(maraxsis.events.on_init(), function()
+    -- Most fluids are compatible with normal pipes
+    for _, fluid_name in ipairs({
+          "maraxsis-atmosphere",
+          "maraxsis-saline-water", "maraxsis-brackish-water",
+          "maraxsis-oxygen", "maraxsis-hydrogen"}) do
+        remote.call("call-plumber", "register_fluid", {fluid=fluid_name, category="inert"})
+    end
+
+    -- Treat cryogenic fluid like lava
+    remote.call(
+       "call-plumber", "register_fluid",
+       {fluid="maraxsis-liquid-atmosphere", category="superheated"}
+    )
+end)
+
+end  -- call-plumber


### PR DESCRIPTION
This change makes Maraxsis compatible with Call a Plumber.  It registers Maraxsis's fluids so that Call a Plumber can check if they are compatible with pipes.