### PR TITLE
Prevent duplicate lab input startup crash

### DIFF
--- a/prototypes/vanilla-changes.lua
+++ b/prototypes/vanilla-changes.lua
@@ -2,7 +2,9 @@ for _, lab in pairs(data.raw.lab) do
     for _, input in pairs(lab.inputs or {}) do
         if input == "cryogenic-science-pack" then
             lab.inputs = lab.inputs or {}
-            table.insert(lab.inputs, "hydraulic-science-pack")
+            if not table.find(lab.inputs, "hydraulic-science-pack") then
+                table.insert(lab.inputs, "hydraulic-science-pack")
+            end
             table.sort(lab.inputs, function(a, b)
                 local order_1 = (data.raw.tool[a] and data.raw.tool[a].order) or a
                 local order_2 = (data.raw.tool[b] and data.raw.tool[b].order) or b


### PR DESCRIPTION
If another mod reuses the same lab inputs table or adds the `hydraulic-science-pack` manually to a lab that also uses the `cryogenic-science-pack` you'd get this ugly startup crash:

![Screenshot 2025-03-12 at 10 33 17](https://github.com/user-attachments/assets/68bf2bb6-f955-4562-8342-0fee771640b0)

Whilst the AoP mod could solve it on their end by merely deepcopying it slightly defeats their usecase, and the mod that adds something new to an unique array is kinda responsible for making sure there are no duplicates, so here's a pr for that.

Downstream issues:

https://github.com/AndreusAxolotl/Age-of-Production/issues/14
https://mods.factorio.com/mod/Age-of-Production/discussion/67d0d33a944da7c8cecb1993
https://mods.factorio.com/mod/Age-of-Production/discussion/67d0deb94688f651992c7644