### PR TITLE
updating conditional in project seadragon script in order to not force default recipe on silo so other planets can pick their own rocket part recipe

### DIFF
--- a/scripts/project-seadragon.lua
+++ b/scripts/project-seadragon.lua
@@ -11,8 +11,5 @@ maraxsis.on_event(maraxsis.events.on_built(), function(event)
     if entity.surface.name == "maraxsis" then
         entity.set_recipe("maraxsis-rocket-part")
         entity.recipe_locked = true
-    else
-        entity.set_recipe("rocket-part")
-        entity.recipe_locked = true
     end
 end)


### PR DESCRIPTION
because of how project seadragon scipt works if other mods that load BEFORE maraxsis try to set it's recipe for it's surface it will be overriden by default rocket-part recipe in maraxsis code

I think this was done by accident

removing "else" part of conditional allow other mods to decide for their own surface and don't breaks how maraxsis rocket part recipe work