### PR TITLE
removing rocket silo recipe restriction for surfaces other than maraxsis

### DIFF
--- a/scripts/project-seadragon.lua
+++ b/scripts/project-seadragon.lua
@@ -11,8 +11,5 @@ maraxsis.on_event(maraxsis.events.on_built(), function(event)
     if entity.surface.name == "maraxsis" then
         entity.set_recipe("maraxsis-rocket-part")
         entity.recipe_locked = true
-    elseif not script.active_mods["PlanetsLib"] then
-        entity.set_recipe("rocket-part")
-        entity.recipe_locked = true
     end
 end)


### PR DESCRIPTION
Allowing rocket silo recipes to be set only by planet lib planets of maraxsis is unfair, and maraxsis don't gain anything by doing this