### PR TITLE
compat: update for Factorio 2.1

### DIFF
--- a/compat/aai-industry.lua
+++ b/compat/aai-industry.lua
@@ -1,7 +1,7 @@
 if not mods["aai-industry"] then return end
 if mods.pystellarexpedition then return end
 
-data.raw.recipe["motor"].category = "maraxsis-hydro-plant-or-assembling"
-data.raw.recipe["electric-motor"].category = "maraxsis-hydro-plant-or-assembling"
+data.raw.recipe["motor"].categories = {"maraxsis-hydro-plant-or-assembling"}
+data.raw.recipe["electric-motor"].categories = {"maraxsis-hydro-plant-or-assembling"}
 
 data.raw.item["maraxsis-glass-panes"].localised_name = {"item-name.maraxsis-reinforced-glass"}

--- a/compat/krastorio-2.lua
+++ b/compat/krastorio-2.lua
@@ -130,7 +130,7 @@ data.raw.technology["kr-quantum-computer"].unit.ingredients = {
 }
 
 if not mods["no-quality"] then
-    data.raw["assembling-machine"]["kr-quantum-computer"].effect_receiver.base_effect.quality = 5
+    data.raw["assembling-machine"]["kr-quantum-computer"].effect_receiver.base_effect.quality = 0.5
 end
 
 data.raw.recipe["kr-quantum-computer"].categories = {"maraxsis-hydro-plant"}

--- a/compat/krastorio-2.lua
+++ b/compat/krastorio-2.lua
@@ -1,8 +1,9 @@
 if not mods["Krastorio2-spaced-out"] and not mods["Krastorio2"] then return end
 
 if not mods["Tech_Cards_For_Modded_Planets"] then
-    data.raw.tool["hydraulic-science-pack"].icon = "__maraxsis__/graphics/icons/hydraulic-tech-card.png"
-    data.raw.tool["hydraulic-science-pack"].localised_name = {"item-name.hydraulic-tech-card"}
+    local hydraulic_pack = (data.raw.tool and data.raw.tool["hydraulic-science-pack"]) or data.raw.item["hydraulic-science-pack"]
+    hydraulic_pack.icon = "__maraxsis__/graphics/icons/hydraulic-tech-card.png"
+    hydraulic_pack.localised_name = {"item-name.hydraulic-tech-card"}
     data.raw.technology["hydraulic-science-pack"].icon = "__maraxsis__/graphics/technology/hydraulic-tech-card.png"
     data.raw.technology["hydraulic-science-pack"].localised_name = {"item-name.hydraulic-tech-card"}
 end
@@ -32,7 +33,7 @@ data:extend {{
         {type = "item", name = "hydraulic-research-data", amount = 1},
     },
     allow_productivity = true,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     auto_recycle = false,
     surface_conditions = maraxsis.surface_conditions(),
 }}
@@ -54,7 +55,7 @@ data:extend {{
         {type = "item", name = "hydraulic-science-pack", amount = 5},
     },
     allow_productivity = true,
-    category = "kr-tech-cards",
+    categories = {"kr-tech-cards"},
     auto_recycle = false,
     surface_conditions = maraxsis.surface_conditions(),
 }}
@@ -132,7 +133,7 @@ if not mods["no-quality"] then
     data.raw["assembling-machine"]["kr-quantum-computer"].effect_receiver.base_effect.quality = 5
 end
 
-data.raw.recipe["kr-quantum-computer"].category = "maraxsis-hydro-plant"
+data.raw.recipe["kr-quantum-computer"].categories = {"maraxsis-hydro-plant"}
 
 data.raw.recipe["kr-quantum-computer"].ingredients = {
     {type = "item", name = "kr-research-server",   amount = 3},

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -55,7 +55,7 @@ if data.raw["technology"]["maraxsis-promethium-productivity"] then
 end
 
 for _, recipe in pairs(data.raw.recipe) do
-    if recipe.category == "maraxsis-hydro-plant-or-assembling" then
+    if recipe.categories and table.find(recipe.categories, "maraxsis-hydro-plant-or-assembling") then
         recipe.always_show_made_in = true
     end
 end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -94,7 +94,7 @@ for recipe, category in pairs {
 } do
     local recipe = data.raw.recipe[recipe]
     recipe.hidden_in_factoriopedia = false
-    recipe.category = category
+    recipe.categories = {category}
     recipe.subgroup = "maraxsis-atmosphere-barreling"
 end
 data.raw.recipe["empty-maraxsis-atmosphere-barrel"].results[1].temperature = 25
@@ -108,9 +108,9 @@ end
 
 if not mods.pystellarexpedition then
     data.raw.recipe["maraxsis-glass-panes-recycling"].results = {
-        {type = "item", name = maraxsis_constants.SAND_ITEM_NAME,      amount = 1, probability = 0.75},
-        {type = "item", name = "salt",      amount = 1, probability = 0.5},
-        {type = "item", name = "limestone", amount = 1, probability = 0.25},
+        {type = "item", name = maraxsis_constants.SAND_ITEM_NAME,      amount = 1, independent_probability = 0.75},
+        {type = "item", name = "salt",      amount = 1, independent_probability = 0.5},
+        {type = "item", name = "limestone", amount = 1, independent_probability = 0.25},
     }
 end
 

--- a/info.json
+++ b/info.json
@@ -5,9 +5,9 @@
   "author": "notnotmelon",
   "homepage": "https://github.com/notnotmelon/maraxsis",
   "version": "1.31.8",
-  "factorio_version": "2.0",
+  "factorio_version": "2.1",
   "dependencies": [
-    "base >= 2.0.58",
+    "base >= 2.1",
     "space-age >= 2.0.58",
     "SpidertronPatrols >= 2.5.5",
     "FluidMustFlow >= 1.4.2",

--- a/migrations/coral.lua
+++ b/migrations/coral.lua
@@ -17,7 +17,6 @@ local function coral_created(event)
             force = force_index,
             create_build_effect_smoke = false
         }
-        new_coral.active = false
         new_coral.destructible = false
         new_coral.minable_flag = false
         coral_animation[i] = new_coral

--- a/migrations/fishing-tower.lua
+++ b/migrations/fishing-tower.lua
@@ -11,7 +11,7 @@ for _, entity in pairs(surface.find_entities_filtered {name = "maraxsis-fishing-
     }
 
     fish_spawner.destructible = false
-    fish_spawner.active = true
+    fish_spawner.disabled_by_script = false
     fish_spawner.operable = false
     fish_spawner.minable_flag = false
 

--- a/prototypes/entity/conduit.lua
+++ b/prototypes/entity/conduit.lua
@@ -22,7 +22,7 @@ data:extend {{
         {type = "item", name = "maraxsis-conduit", amount = 1},
     },
     allow_productivity = false,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     auto_recycle = true,
     surface_conditions = maraxsis.surface_conditions(),
 }}

--- a/prototypes/entity/fish.lua
+++ b/prototypes/entity/fish.lua
@@ -145,7 +145,7 @@ data:extend {{
     results = {
         {type = "item", name = "carbon", amount = 8},
     },
-    category = "maraxsis-smelting-or-biochamber",
+    categories = {"maraxsis-smelting-or-biochamber"},
     allow_productivity = true,
     main_product = "carbon",
     icon = "__maraxsis__/graphics/icons/burnt-fish.png",
@@ -196,7 +196,7 @@ data:extend {{
     auto_recycle = false,
     allow_decomposition = false,
     allow_productivity = true,
-    category = "organic",
+    categories = {"organic"},
     subgroup = "nauvis-agriculture",
     order = "g[maraxsis]"
 }}
@@ -240,7 +240,7 @@ data:extend {{
         {type = "item", name = "maraxsis-microplastics", amount = 10},
         {type = "item", name = "jelly",                  amount = 10},
     },
-    category = "organic-or-assembling",
+    categories = {"organic", "crafting"},
     localised_name = {"recipe-name.maraxsis-microplastics"},
     main_product = "maraxsis-microplastics",
     allow_productivity = true,
@@ -268,7 +268,7 @@ data:extend {{
     results = {
         {type = "item", name = "plastic-bar", amount = 1},
     },
-    category = "smelting",
+    categories = {"smelting"},
     allow_productivity = true,
     main_product = "plastic-bar",
     emissions_multiplier = 3,

--- a/prototypes/entity/fishing-tower.lua
+++ b/prototypes/entity/fishing-tower.lua
@@ -25,7 +25,7 @@ if not mods.pystellarexpedition then
         },
         allow_productivity = true,
         main_product = "maraxsis-fish-food",
-        category = "maraxsis-hydro-plant-or-biochamber"
+        categories = {"maraxsis-hydro-plant-or-biochamber"}
     }}
 end
 
@@ -53,7 +53,7 @@ data:extend {{
     },
     allow_productivity = false,
     main_product = "maraxsis-fishing-tower",
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     surface_conditions = maraxsis.surface_conditions(),
 }}
 

--- a/prototypes/entity/hydro-plant.lua
+++ b/prototypes/entity/hydro-plant.lua
@@ -134,7 +134,7 @@ data:extend {{
     water_reflection = require("__space-age__.prototypes.entity.electromagnetic-plant-pictures").water_reflection,
     collision_box = {{-1.9, -1.9}, {1.9, 1.9}},
     selection_box = {{-2, -2}, {2, 2}},
-    effect_receiver = (not mods["no-quality"]) and {base_effect = {quality = 5}} or nil,
+    effect_receiver = (not mods["no-quality"]) and {base_effect = {quality = 0.5}} or nil,
     drawing_box_vertical_extension = 1,
     damaged_trigger_effect = hit_effects.entity(),
     fluid_boxes = {

--- a/prototypes/entity/hydro-plant.lua
+++ b/prototypes/entity/hydro-plant.lua
@@ -15,7 +15,7 @@ data:extend {{
     prerequisites = {"planet-discovery-maraxsis"},
     research_trigger = {
         type = "mine-entity",
-        entity = "big-sand-rock-underwater"
+        entities = {"big-sand-rock-underwater"}
     },
     order = "ea[hydro-plant]",
 }}
@@ -128,7 +128,7 @@ data:extend {{
     heating_energy = "2000kW",
     module_slots = 4,
     icons_positioning = {
-        {inventory_index = defines.inventory.furnace_modules, shift = {0, 1}}
+        {inventory_index = defines.inventory.crafter_modules, shift = {0, 1}}
     },
     allowed_effects = {"consumption", "speed", "productivity", "pollution", "quality"},
     water_reflection = require("__space-age__.prototypes.entity.electromagnetic-plant-pictures").water_reflection,
@@ -208,7 +208,7 @@ local extra_module_slots = table.deepcopy(data.raw["assembling-machine"]["maraxs
 extra_module_slots.name = "maraxsis-hydro-plant-extra-module-slots"
 extra_module_slots.module_slots = extra_module_slots.module_slots + 4
 extra_module_slots.icons_positioning = {{
-    inventory_index = defines.inventory.assembling_machine_modules, shift = {0, 0.9}, max_icons_per_row = 4
+    inventory_index = defines.inventory.crafter_modules, shift = {0, 0.9}, max_icons_per_row = 4
 }}
 extra_module_slots.hidden_in_factoriopedia = true
 extra_module_slots.factoriopedia_alternative = "maraxsis-hydro-plant"
@@ -240,7 +240,7 @@ data:extend {{
     results = {
         {type = "item", name = "maraxsis-hydro-plant", amount = 1},
     },
-    category = "maraxsis-hydro-plant-or-chemistry",
+    categories = {"maraxsis-hydro-plant-or-chemistry"},
     surface_conditions = maraxsis.surface_conditions(),
 }}
 
@@ -255,7 +255,7 @@ data:extend {{
         {type = "item", name = "holmium-plate", amount = 5},
     },
     energy_required = data.raw.recipe["holmium-plate"].energy_required * 5,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     enabled = false,
     auto_recycle = false,
     icons = {

--- a/prototypes/entity/oversized-steam-turbine.lua
+++ b/prototypes/entity/oversized-steam-turbine.lua
@@ -24,7 +24,7 @@ data:extend {{
     results = {
         {type = "item", name = "maraxsis-oversized-steam-turbine", amount = 1},
     },
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     surface_conditions = maraxsis.surface_conditions(),
 }}
 
@@ -251,7 +251,7 @@ data:extend {{
         {type = "fluid", name = "water", amount = 1}
     },
     results = {},
-    category = "maraxsis-supercritical-steam",
+    categories = {"maraxsis-supercritical-steam"},
     icon = "__maraxsis__/graphics/icons/oversized-steam-turbine.png",
 }}
 

--- a/prototypes/entity/pressure-dome.lua
+++ b/prototypes/entity/pressure-dome.lua
@@ -57,7 +57,7 @@ data:extend {{
         {type = "item", name = "maraxsis-pressure-dome", amount = 1},
     },
     energy_required = 10,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
 }}
 
 local function collision_box() return {{-16, -16}, {16, 16}} end

--- a/prototypes/entity/regulator.lua
+++ b/prototypes/entity/regulator.lua
@@ -64,7 +64,7 @@ data:extend {{
     energy_required = 100,
     ingredients = {},
     results = {},
-    category = "maraxsis-regulator",
+    categories = {"maraxsis-regulator"},
     subgroup = "fluid",
     order = "a[fluid]-a[maraxsis-atmosphere]-a[regulator]",
     icon = "__maraxsis__/graphics/icons/atmosphere.png",

--- a/prototypes/entity/salt-reactor.lua
+++ b/prototypes/entity/salt-reactor.lua
@@ -65,7 +65,7 @@ data:extend {{
     damaged_trigger_effect = hit_effects.entity(),
     icon_draw_specification = {shift = {0, -0.5}, scale = 1.5},
     icons_positioning = {{
-        inventory_index = defines.inventory.furnace_modules, shift = {0, 0.9}, max_icons_per_row = 3
+        inventory_index = defines.inventory.crafter_modules, shift = {0, 0.9}, max_icons_per_row = 3
     }},
     graphics_set = {
         structure = {
@@ -187,7 +187,7 @@ data:extend {{
         {type = "fluid", name = "molten-salt", amount = 50},
     },
     allow_productivity = true,
-    category = "metallurgy",
+    categories = {"metallurgy"},
     auto_recycle = false,
 }}
 
@@ -219,7 +219,7 @@ data:extend {{
     results = {
         {type = "item", name = "msr-fuel-cell", amount = 1},
     },
-    category = "crafting-with-fluid",
+    categories = {"crafting-with-fluid"},
     allow_productivity = true,
     auto_recycle = false,
 }}
@@ -238,7 +238,7 @@ data:extend {{
     results = {
         {type = "item", name = "maraxsis-salt-reactor", amount = 1},
     },
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     surface_conditions = maraxsis.surface_conditions(),
 }}
 

--- a/prototypes/entity/sand-extractor.lua
+++ b/prototypes/entity/sand-extractor.lua
@@ -6,7 +6,7 @@ data:extend {{
 data:extend {{
     type = "recipe",
     name = "maraxsis-sand-extraction",
-    category = "maraxsis-sand-extraction",
+    categories = {"maraxsis-sand-extraction"},
     energy_required = 10,
     ingredients = {},
     results = {

--- a/prototypes/entity/sonar.lua
+++ b/prototypes/entity/sonar.lua
@@ -51,7 +51,7 @@ data:extend {{
         {type = "item", name = "maraxsis-sonar", amount = 1},
     },
     energy_required = 10,
-    category = "maraxsis-hydro-plant"
+    categories = {"maraxsis-hydro-plant"}
 }}
 
 data:extend {maraxsis.merge(data.raw.radar.radar, {

--- a/prototypes/entity/submarine.lua
+++ b/prototypes/entity/submarine.lua
@@ -101,7 +101,7 @@ for i = 1, 2 do
         results = {{type = "item", name = name, amount = 1}},
         enabled = false,
         energy_required = 10,
-        category = i == 1 and "maraxsis-hydro-plant-or-assembling" or "maraxsis-hydro-plant",
+        categories = {i == 1 and "maraxsis-hydro-plant-or-assembling" or "maraxsis-hydro-plant"},
     }
 
     local lamp_layer = {

--- a/prototypes/entity/submarine.lua
+++ b/prototypes/entity/submarine.lua
@@ -358,7 +358,7 @@ data:extend {{
 
 data:extend {{
     type = "custom-input",
-    key_sequence = "CONTROL + ENTER",
+    key_sequence = "CONTROL + RETURN",
     name = "maraxsis-trench-submerge",
     consuming = "game-only",
     alternative_key_sequence = "",

--- a/prototypes/entity/trench-duct.lua
+++ b/prototypes/entity/trench-duct.lua
@@ -3,7 +3,7 @@ local constants = require "__FluidMustFlow__.prototypes.constants"
 data.raw.technology["ducts"].unit = nil
 data.raw.technology["ducts"].research_trigger = {
     type = "mine-entity",
-    entity = "maraxsis-chimney"
+    entities = {"maraxsis-chimney"}
 }
 data.raw.technology["ducts"].prerequisites = {"sp-spidertron-automation", "planet-discovery-maraxsis"}
 
@@ -39,7 +39,7 @@ table.insert(data.raw.technology["ducts"].effects, {
 for _, effect in pairs(data.raw.technology["ducts"].effects) do
     if effect.type == "unlock-recipe" then
         local recipe = data.raw.recipe[effect.recipe]
-        recipe.category = mods.pystellarexpedition and "advanced-crafting" or "maraxsis-hydro-plant-or-assembling"
+        recipe.categories = {mods.pystellarexpedition and "advanced-crafting" or "maraxsis-hydro-plant-or-assembling"}
         for _, ingredient in pairs(recipe.ingredients) do
             if ingredient.name == "iron-plate" then
                 ingredient.name = "tungsten-plate"

--- a/prototypes/fluid-void.lua
+++ b/prototypes/fluid-void.lua
@@ -22,7 +22,7 @@ for _, fluid in pairs(data.raw.fluid) do
     data:extend {{
         type = "recipe",
         name = "maraxsis-fluid-void-" .. fluid.name,
-        category = "maraxsis-hydro-plant",
+        categories = {"maraxsis-hydro-plant"},
         subgroup = "maraxsis-fluid-void",
         order = fluid.order,
         icons = generate_void_icons(fluid),

--- a/prototypes/recipe/deepsea-research.lua
+++ b/prototypes/recipe/deepsea-research.lua
@@ -17,7 +17,7 @@ local production_science = table.deepcopy(data.raw.recipe["production-science-pa
 local utility_science = table.deepcopy(data.raw.recipe["utility-science-pack"])
 
 local function update_recipe_icon(recipe, fluid)
-    local science_pack = data.raw.tool[recipe.name]
+    local science_pack = (data.raw.tool and data.raw.tool[recipe.name]) or data.raw.item[recipe.name]
     if not (recipe.icon or science_pack.icon) then return end
     fluid = data.raw.fluid[fluid]
     recipe.icons = {
@@ -52,7 +52,7 @@ for _, recipe in pairs {
 } do
     recipe.localised_name = {"item-name." .. recipe.name}
     recipe.name = "maraxsis-deepsea-research-" .. recipe.name
-    recipe.category = "maraxsis-hydro-plant"
+    recipe.categories = {"maraxsis-hydro-plant"}
     recipe.subgroup = "maraxsis-deepsea-research"
     recipe.enabled = false
     recipe.auto_recycle = false

--- a/prototypes/research-vessel.lua
+++ b/prototypes/research-vessel.lua
@@ -38,8 +38,8 @@ local function generate_recipe_icons(icons, science_pack, icon_shift)
         table.insert(icons,
             {
                 icon = science_pack.icon,
-                icon_size = (science_pack.icon_size or defines.default_icon_size),
-                scale = 16.0 / (science_pack.icon_size or defines.default_icon_size), -- scale = 0.5 * 32 / icon_size simplified
+                icon_size = (science_pack.icon_size or defines.constant.default_icon_size),
+                scale = 16.0 / (science_pack.icon_size or defines.constant.default_icon_size), -- scale = 0.5 * 32 / icon_size simplified
                 shift = icon_shift
             }
         )
@@ -48,7 +48,7 @@ local function generate_recipe_icons(icons, science_pack, icon_shift)
             icons,
             science_pack.icons,
             {scale = 0.5, shift = icon_shift},
-            science_pack.icon_size or defines.default_icon_size
+            science_pack.icon_size or defines.constant.default_icon_size
         )
     end
 
@@ -56,7 +56,7 @@ local function generate_recipe_icons(icons, science_pack, icon_shift)
 end
 
 local function pressurize(science_pack_name)
-    local science_pack = data.raw.tool[science_pack_name] or data.raw.item[science_pack_name]
+    local science_pack = (data.raw.tool and data.raw.tool[science_pack_name]) or data.raw.item[science_pack_name]
     if not science_pack then return end
 
     if science_pack.spoil_result and science_pack.spoil_result ~= "spoilage" then
@@ -115,7 +115,7 @@ local function pressurize(science_pack_name)
         },
         allow_productivity = false,
         allow_quality = false,
-        category = "chemistry",
+        categories = {"chemistry"},
         auto_recycle = false,
         hide_from_signal_gui = false,
         allow_decomposition = false,
@@ -146,11 +146,11 @@ local function pressurize(science_pack_name)
         },
         results = {
             {type = "item", name = science_pack_name,                amount = 100, ignored_by_stats = 100, ignored_by_productivity = 100},
-            {type = "item", name = "maraxsis-empty-research-vessel", amount = 1,   ignored_by_stats = 1,   ignored_by_productivity = 1,  probability = 0.99},
+            {type = "item", name = "maraxsis-empty-research-vessel", amount = 1,   ignored_by_stats = 1,   ignored_by_productivity = 1,  independent_probability = 0.99},
         },
         allow_productivity = false,
         allow_quality = false,
-        category = "chemistry",
+        categories = {"chemistry"},
         auto_recycle = false,
         unlock_results = false,
         icons = generate_recipe_icons({

--- a/prototypes/spidertron-patrols.lua
+++ b/prototypes/spidertron-patrols.lua
@@ -13,7 +13,7 @@ submarine_automation.order = "eb[submarine-automation]"
 submarine_automation.prerequisites = {"planet-discovery-maraxsis"}
 
 if not mods.pystellarexpedition then
-    data.raw.recipe["sp-spidertron-dock"].category = "maraxsis-hydro-plant-or-assembling"
+    data.raw.recipe["sp-spidertron-dock"].categories = {"maraxsis-hydro-plant-or-assembling"}
 end
 data.raw.recipe["sp-spidertron-dock"].ingredients = {
     {type = "item", name = "tungsten-plate", amount = 16},

--- a/prototypes/technology/abyssal-diving-gear.lua
+++ b/prototypes/technology/abyssal-diving-gear.lua
@@ -35,7 +35,7 @@ data:extend {{
     name = "maraxsis-abyssal-diving-gear",
     enabled = false,
     energy_required = 10,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     ingredients = {
         {type = "item", name = "low-density-structure",            amount = 10},
         {type = "item", name = "quantum-processor",                amount = 20},

--- a/prototypes/technology/atmosphere.lua
+++ b/prototypes/technology/atmosphere.lua
@@ -15,7 +15,7 @@ data:extend {{
 data:extend {{
     type = "recipe",
     name = "maraxsis-atmosphere",
-    category = "chemistry",
+    categories = {"chemistry"},
     energy_required = 10,
     ingredients = {},
     results = {
@@ -83,7 +83,7 @@ data:extend {{
 data:extend {{
     type = "recipe",
     name = "maraxsis-liquid-atmosphere",
-    category = "cryogenics",
+    categories = {"cryogenics"},
     energy_required = 10,
     ingredients = {
         {type = "fluid", name = "maraxsis-atmosphere", amount = 100},
@@ -108,7 +108,7 @@ data:extend {{
 data:extend {{
     type = "recipe",
     name = "maraxsis-liquid-atmosphere-decompression",
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     energy_required = 9,
     ingredients = {
         {type = "fluid", name = "maraxsis-liquid-atmosphere", amount = 1}

--- a/prototypes/technology/depth-charges.lua
+++ b/prototypes/technology/depth-charges.lua
@@ -52,7 +52,7 @@ data:extend {{
     results = {
         {type = "item", name = "maraxsis-big-cliff-explosives", amount = 1},
     },
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
 }}
 
 if not mods.pystellarexpedition then
@@ -60,7 +60,7 @@ if not mods.pystellarexpedition then
         type = "recipe",
         name = "maraxsis-pipe-bomb",
         energy_required = data.raw.recipe["grenade"].energy_required,
-        category = "maraxsis-hydro-plant",
+        categories = {"maraxsis-hydro-plant"},
         enabled = false,
         results = table.deepcopy(data.raw.recipe["grenade"].results),
         ingredients = {

--- a/prototypes/technology/fat-man.lua
+++ b/prototypes/technology/fat-man.lua
@@ -3,7 +3,7 @@ local sounds = require("__base__.prototypes.entity.sounds")
 data:extend {{
     type = "recipe",
     name = "maraxsis-fat-man",
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     ingredients = {
         {type = "item", name = "artillery-shell",                  amount = 1},
         {type = "item", name = "maraxsis-super-sealant-substance", amount = 1},

--- a/prototypes/technology/glass.lua
+++ b/prototypes/technology/glass.lua
@@ -28,7 +28,7 @@ data:extend {{
     prerequisites = {"planet-discovery-maraxsis"},
     research_trigger = {
         type = "mine-entity",
-        entity = "maraxsis-mollusk-husk"
+        entities = {"maraxsis-mollusk-husk"}
     },
     order = "eb[glassworking]",
 }}
@@ -67,7 +67,7 @@ data:extend {{
         {type = "item", name = "maraxsis-glass-panes", amount = 1},
     },
     allow_productivity = true,
-    category = "metallurgy",
+    categories = {"metallurgy"},
     auto_recycle = true
 }}
 
@@ -166,7 +166,7 @@ data:extend {{
     icon = "__maraxsis__/graphics/icons/limestone-processing.png",
     icon_size = 64,
     allow_productivity = true,
-    category = "maraxsis-hydro-plant-or-foundry",
+    categories = {"maraxsis-hydro-plant-or-foundry"},
     allow_decomposition = false,
     main_product = "calcite",
     auto_recycle = false,

--- a/prototypes/technology/hydraulic-science-pack.lua
+++ b/prototypes/technology/hydraulic-science-pack.lua
@@ -1,15 +1,13 @@
+-- 2.1: science packs are plain items (type "item"), not "tool"; durability is gone.
 data:extend {{
-    type = "tool",
+    type = "item",
     name = "hydraulic-science-pack",
     icon = "__maraxsis__/graphics/icons/hydraulic-science-pack.png",
     icon_size = 64,
     subgroup = "science-pack",
     order = "j[hydraulic-science-pack]",
-    stack_size = data.raw.tool["automation-science-pack"].stack_size,
-    durability = data.raw.tool["automation-science-pack"].durability,
-    durability_description_key = data.raw.tool["automation-science-pack"].durability_description_key,
-    durability_description_value = data.raw.tool["automation-science-pack"].durability_description_value,
-    weight = data.raw.tool["automation-science-pack"].weight,
+    stack_size = data.raw.item["automation-science-pack"].stack_size,
+    weight = data.raw.item["automation-science-pack"].weight,
 }}
 
 data:extend {{
@@ -49,7 +47,7 @@ data:extend {{
         {type = "item", name = "hydraulic-science-pack", amount = 1},
     },
     allow_productivity = true,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     auto_recycle = false,
     surface_conditions = maraxsis.surface_conditions(),
 }}

--- a/prototypes/technology/project-seadragon.lua
+++ b/prototypes/technology/project-seadragon.lua
@@ -59,7 +59,7 @@ data:extend {{
     results = {
         {type = "item", name = "maraxsis-super-sealant-substance", amount = 1},
     },
-    category = "chemistry-or-cryogenics",
+    categories = {"chemistry", "cryogenics"},
     allow_productivity = true,
     auto_recycle = false,
 }}

--- a/prototypes/technology/recipes.lua
+++ b/prototypes/technology/recipes.lua
@@ -10,7 +10,7 @@ data:extend {{
     },
     energy_required = 2,
     enabled = false,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     surface_conditions = {{
         property = "pressure",
         min = 400000,
@@ -32,7 +32,7 @@ data:extend {{
         {type = "fluid", name = "heavy-oil", amount = 10},
     },
     allow_productivity = true,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     energy_required = 2,
     subgroup = "fluid-recipes",
     order = "b[fluid-chemistry]-c[petroleum-gas-cracking]",

--- a/prototypes/technology/research-vessel.lua
+++ b/prototypes/technology/research-vessel.lua
@@ -43,7 +43,6 @@ data:extend {{
         {type = "item", name = "maraxsis-empty-research-vessel", amount = 1},
     },
     allow_productivity = false,
-    category = "crafting",
     auto_recycle = true,
 }}
 

--- a/prototypes/technology/stone-centrifuging.lua
+++ b/prototypes/technology/stone-centrifuging.lua
@@ -1,14 +1,14 @@
 data:extend {{
     type = "recipe",
     name = "maraxsis-stone-centrifuging",
-    category = "centrifuging",
+    categories = {"centrifuging"},
     enabled = false,
     energy_required = 2,
     ingredients = {
         {type = "item", name = "stone", amount = 10}
     },
     results = {
-        {type = "item", name = "uranium-ore", amount = 1, probability = 0.01},
+        {type = "item", name = "uranium-ore", amount = 1, independent_probability = 0.01},
     },
     icon = "__maraxsis__/graphics/icons/stone-centrifuging.png",
     icon_size = 64,

--- a/prototypes/technology/water-treatment.lua
+++ b/prototypes/technology/water-treatment.lua
@@ -83,7 +83,7 @@ data:extend {{
         {type = "fluid", name = "oxygen",   amount = 100},
         {type = "fluid", name = "hydrogen", amount = 200},
     },
-    category = "maraxsis-hydro-plant-or-chemistry",
+    categories = {"maraxsis-hydro-plant-or-chemistry"},
     icon = "__maraxsis__/graphics/icons/saline-electrolysis.png",
     icon_size = 64,
     auto_recycle = false,
@@ -108,7 +108,7 @@ data:extend {{
         {type = "fluid", name = "water", amount = 300},
     },
     allow_productivity = true,
-    category = "chemistry-or-cryogenics",
+    categories = {"chemistry", "cryogenics"},
     main_product = "water",
 }}
 add_to_tech("maraxsis-water")
@@ -134,7 +134,7 @@ data:extend {{
         {type = "fluid", name = "maraxsis-brackish-water",        amount = 100},
         {type = "item",  name = "maraxsis-saturated-salt-filter", amount = 1,  ignored_by_stats = 1, ignored_by_productivity = 1},
     },
-    category = "maraxsis-hydro-plant-or-chemistry",
+    categories = {"maraxsis-hydro-plant-or-chemistry"},
     auto_recycle = false,
     main_product = "maraxsis-brackish-water",
     allow_productivity = true,
@@ -181,7 +181,7 @@ data:extend {{
     results = {
         {type = "item", name = "maraxsis-salt-filter", amount = 1},
     },
-    category = "maraxsis-hydro-plant-or-assembling",
+    categories = {"maraxsis-hydro-plant-or-assembling"},
     allow_productivity = true,
     auto_recycle = false,
 }}
@@ -197,11 +197,11 @@ data:extend {{
         {type = "fluid", name = "water",                          amount = 20},
     },
     results = {
-        {type = "item",  name = "maraxsis-salt-filter",    amount = 1, probability = 0.95, ignored_by_stats = 1},
-        {type = "item",  name = "carbon-fiber",            amount = 1, probability = 0.025},
+        {type = "item",  name = "maraxsis-salt-filter",    amount = 1, independent_probability = 0.95, ignored_by_stats = 1},
+        {type = "item",  name = "carbon-fiber",            amount = 1, independent_probability = 0.025},
         {type = "fluid", name = "maraxsis-brackish-water", amount = 20},
     },
-    category = "maraxsis-hydro-plant-or-chemistry",
+    categories = {"maraxsis-hydro-plant-or-chemistry"},
     main_product = "maraxsis-salt-filter",
     allow_productivity = false,
     icon = "__maraxsis__/graphics/icons/salt-filter-cleaning.png",
@@ -226,7 +226,7 @@ data:extend {{
     icon = "__maraxsis__/graphics/icons/hydrolox-rocket-fuel.png",
     icon_size = 64,
     allow_productivity = true,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     main_product = "rocket-fuel",
 }}
 add_to_tech("maraxsis-hydrolox-rocket-fuel")

--- a/prototypes/technology/wyrm.lua
+++ b/prototypes/technology/wyrm.lua
@@ -81,7 +81,7 @@ data:extend {{
         {type = "item", name = "maraxsis-wyrm-specimen", amount = 1},
     },
     auto_recycle = false,
-    category = "maraxsis-hydro-plant",
+    categories = {"maraxsis-hydro-plant"},
     surface_conditions = {{
         property = "pressure",
         min = 400000,

--- a/prototypes/vanilla-changes.lua
+++ b/prototypes/vanilla-changes.lua
@@ -6,10 +6,12 @@ if not mods.pystellarexpedition then
                 if not table.find(lab.inputs, "hydraulic-science-pack") then
                     table.insert(lab.inputs, "hydraulic-science-pack")
                 end
+                local function pack_order(name)
+                    local proto = (data.raw.tool and data.raw.tool[name]) or data.raw.item[name]
+                    return (proto and proto.order) or name
+                end
                 table.sort(lab.inputs, function(a, b)
-                    local order_1 = (data.raw.tool[a] and data.raw.tool[a].order) or a
-                    local order_2 = (data.raw.tool[b] and data.raw.tool[b].order) or b
-                    return order_1 < order_2
+                    return pack_order(a) < pack_order(b)
                 end)
                 break
             end
@@ -36,17 +38,17 @@ if settings.startup["maraxsis-add-hydraulic-science"].value and not mods.pystell
 end
 
 if not mods.pystellarexpedition then
-    data.raw.recipe["pump"].category = "maraxsis-hydro-plant-or-assembling"
-    data.raw.recipe["pipe"].category = "maraxsis-hydro-plant-or-assembling"
-    data.raw.recipe["pipe-to-ground"].category = "maraxsis-hydro-plant-or-assembling"
-    data.raw.recipe["storage-tank"].category = "maraxsis-hydro-plant-or-assembling"
-    data.raw.recipe["coal-synthesis"].category = "maraxsis-hydro-plant-or-chemistry"
+    data.raw.recipe["pump"].categories = {"maraxsis-hydro-plant-or-assembling"}
+    data.raw.recipe["pipe"].categories = {"maraxsis-hydro-plant-or-assembling"}
+    data.raw.recipe["pipe-to-ground"].categories = {"maraxsis-hydro-plant-or-assembling"}
+    data.raw.recipe["storage-tank"].categories = {"maraxsis-hydro-plant-or-assembling"}
+    data.raw.recipe["coal-synthesis"].categories = {"maraxsis-hydro-plant-or-chemistry"}
 
     if not mods["foundry-expanded"] then
-        data.raw.recipe["engine-unit"].category = "maraxsis-hydro-plant-or-advanced-crafting"
+        data.raw.recipe["engine-unit"].categories = {"maraxsis-hydro-plant-or-advanced-crafting"}
     end
     if not mods["electromagnetic-plant-expanded"] then
-        data.raw.recipe["electric-engine-unit"].category = "maraxsis-hydro-plant-or-advanced-crafting"
+        data.raw.recipe["electric-engine-unit"].categories = {"maraxsis-hydro-plant-or-advanced-crafting"}
     end
 end
 
@@ -99,9 +101,9 @@ end
 data.raw.technology["spidertron"].effects = new_spidertron_effects
 
 if not mods.pystellarexpedition then
-    data.raw.recipe["ice-melting"].category = "maraxsis-hydro-plant-or-chemistry"
-    data.raw.recipe["advanced-thruster-fuel"].category = "maraxsis-hydro-plant-or-chemistry"
-    data.raw.recipe["advanced-thruster-oxidizer"].category = "maraxsis-hydro-plant-or-chemistry"
+    data.raw.recipe["ice-melting"].categories = {"maraxsis-hydro-plant-or-chemistry"}
+    data.raw.recipe["advanced-thruster-fuel"].categories = {"maraxsis-hydro-plant-or-chemistry"}
+    data.raw.recipe["advanced-thruster-oxidizer"].categories = {"maraxsis-hydro-plant-or-chemistry"}
 end
 
 -- https://github.com/notnotmelon/maraxsis/issues/23

--- a/scripts/fishing-tower.lua
+++ b/scripts/fishing-tower.lua
@@ -27,7 +27,7 @@ maraxsis.on_event(maraxsis.events.on_built(), function(event)
     }
 
     fish_spawner.destructible = false
-    fish_spawner.active = true
+    fish_spawner.disabled_by_script = false
     fish_spawner.operable = false
     fish_spawner.minable_flag = false
 

--- a/scripts/map-gen/maraxsis.lua
+++ b/scripts/map-gen/maraxsis.lua
@@ -21,7 +21,6 @@ maraxsis.on_event(defines.events.on_chunk_generated, function(event)
 		position = {x, y},
 		create_build_effect_smoke = false
 	}
-	fancy_water.active = false
 	fancy_water.destructible = false
 	fancy_water.minable_flag = false
 end)
@@ -61,7 +60,6 @@ local function coral_created(event)
 			force = force_index,
 			create_build_effect_smoke = false
 		}
-		new_coral.active = false
 		new_coral.destructible = false
 		new_coral.minable_flag = false
 		coral_animation[i] = new_coral

--- a/scripts/pressure-dome.lua
+++ b/scripts/pressure-dome.lua
@@ -124,8 +124,8 @@ local function disable_due_to_dome_low_pressure(entity, powered_and_has_fluid)
     if not DOME_DISABLEABLE_TYPES[entity.type] or DOME_EXCLUDED_FROM_DISABLE[entity.name] then return end
 
     local should_be_active = not not powered_and_has_fluid
-    if entity.active == should_be_active then return end
-    entity.active = should_be_active
+    if entity.disabled_by_script == (not should_be_active) then return end
+    entity.disabled_by_script = not should_be_active
 
     storage.flooded_warning_info_icons = storage.flooded_warning_info_icons or {}
     local warning = storage.flooded_warning_info_icons[entity.unit_number]
@@ -418,7 +418,7 @@ local function place_collision_boxes(pressure_dome_data, health, player)
             player = player -- setup the undo queue
         }
         collision_box.health = health
-        collision_box.active = false
+        collision_box.disabled_by_script = true
         collision_box.operable = false -- vanilla bug: operable does nothing on cars
         table.insert(pressure_dome_data.collision_boxes, collision_box)
 

--- a/scripts/pressure-dome.lua
+++ b/scripts/pressure-dome.lua
@@ -552,10 +552,10 @@ maraxsis.on_nth_tick(631, function()
             regulator_fluidbox = pressure_dome_data.regulator_fluidbox
         end
 
-        local fluid = regulator_fluidbox.fluidbox[1]
+        local fluid = regulator_fluidbox.get_fluid(1)
         if fluid and fluid.temperature ~= 25 then
             fluid.temperature = 25
-            regulator_fluidbox.fluidbox[1] = fluid
+            regulator_fluidbox.set_fluid(1, fluid)
         end
     end
 end)

--- a/scripts/salt-reactor.lua
+++ b/scripts/salt-reactor.lua
@@ -15,8 +15,8 @@ local function is_salt_reactor_active(reactor)
         return false
     end
 
-    local fluidbox = reactor.fluidbox[1]
-    return fluidbox and fluidbox.name == "water" and fluidbox.amount > 1
+    local fluid = reactor.get_fluid(1)
+    return fluid and fluid.name == "water" and fluid.amount > 1
 end
 
 local SUPERCRITICAL_STEAM_ALLOW_LIST = table.invert {
@@ -47,15 +47,10 @@ maraxsis.on_nth_tick(597, function()
             goto continue
         end
 
-        for _, neighbours in pairs(duct_exhaust.neighbours) do
+        for _, neighbours in pairs(duct_exhaust.fluidbox_neighbours) do
             for _, neighbour in pairs(neighbours) do
                 if not SUPERCRITICAL_STEAM_ALLOW_LIST[neighbour.name] then
-                    local fluidbox = neighbour.fluidbox
-                    if fluidbox then
-                        for i = 1, #fluidbox do
-                            fluidbox.flush(1, "maraxsis-supercritical-steam")
-                        end
-                    end
+                    neighbour.clear_fluids()
 
                     local position = neighbour.position
                     local force = neighbour.force_index
@@ -187,8 +182,8 @@ maraxsis.on_event(maraxsis.events.on_built(), function(event)
         assembler.destructible = false
         assembler.operable = false
         assembler.minable_flag = false
-        assembler.fluidbox.add_linked_connection(0, entity, 0)
-        assembler.fluidbox.add_linked_connection(1, entity, 1)
+        assembler.add_fluid_box_linked_connection(0, entity, 0)
+        assembler.add_fluid_box_linked_connection(1, entity, 1)
         storage.oversized_steam_turbines[entity.unit_number] = assembler
     elseif entity.name == "duct-exhaust" then
         storage.duct_exhausts[entity.unit_number] = entity

--- a/scripts/trench-duct.lua
+++ b/scripts/trench-duct.lua
@@ -26,7 +26,7 @@ maraxsis.on_event(maraxsis.events.on_built(), function(event)
         direction = opposite_direction(surface_duct.direction)
     }
 
-    surface_duct.fluidbox.add_linked_connection(0, trench_duct, 0)
+    surface_duct.add_fluid_box_linked_connection(0, trench_duct, 0)
 
     local trench_duct_data = {
         surface_duct = surface_duct,


### PR DESCRIPTION
Data stage: science packs are items not tools, recipe category->categories, product probability->independent_probability, mine-entity trigger entities list, crafter_modules inventory, defines.constant.default_icon_size, removed combined recipe-categories.

Control stage: removed LuaEntity.fluidbox/.neighbours migrated to get_fluid/set_fluid/add_fluid_box_linked_connection/clear_fluids/fluidbox_neighbours; simple-entity active is read-only.

Bump version to 1.32.0 and add changelog entry.