### PR TITLE
PlanetsLib rocket part assignment

### DIFF
--- a/migrations/PlanetsLib-rocket-silo.json
+++ b/migrations/PlanetsLib-rocket-silo.json
@@ -1,0 +1,8 @@
+{
+    "entity": [
+        [
+            "maraxsis-rocket-silo",
+            "rocket-silo"
+        ]
+    ]
+}

--- a/migrations/PlanetsLib-rocket-silo.lua
+++ b/migrations/PlanetsLib-rocket-silo.lua
@@ -1,0 +1,10 @@
+local rocket_silo_lib = require("__PlanetsLib__.scripts.rocket-parts")
+if game.planets["maraxsis"] then
+    local maraxsis_rocket_silos = game.planets["maraxsis"].surface.find_entities_filtered{{filter_type = "name",name="rocket-silo"}}
+    for _,silo in pairs(maraxsis_rocket_silos) do
+        local fake_event = {
+            entity = silo
+        }
+        rocket_silo_lib.on_built_rocket_silo(fake_event) --Runs PlanetsLib's on_built_rocket_silo code, which locks the rocket silo if configured to. See PlanetsLib.assign_rocket_part_recipe.
+    end
+end

--- a/prototypes/technology/project-seadragon.lua
+++ b/prototypes/technology/project-seadragon.lua
@@ -85,44 +85,4 @@ data:extend {{
     pictures = super_sealant_substance_variants,
 }}
 
--- Adapted from Rubia & Alternative Rocket Sprite Extension.
-local rocket = util.table.deepcopy(data.raw["rocket-silo-rocket"]["rocket-silo-rocket"])
-rocket.name = "maraxsis-rocket-silo-rocket"
-rocket.localised_name = {"entity-name.rocket-silo-rocket"}
-rocket.localised_description = {"entity-description.rocket-silo-rocket"}
-rocket.hidden = true
-rocket.hidden_in_factoriopedia = true
-rocket.rocket_sprite = {
-    filename = "__maraxsis__/graphics/entity/rocket-silo/rocket.png",
-    height = 290,
-    width = 290,
-    scale = 1.2,
-    shift = {0, 6}
-}
-rocket.rocket_rise_offset = {0, -7}
-rocket.rocket_smoke_bottom1_animation.scale = 0.01
-rocket.rocket_smoke_bottom1_animation.hr_version = nil
-rocket.rocket_smoke_bottom2_animation.scale = 0.01
-rocket.rocket_smoke_bottom2_animation.hr_version = nil
-rocket.rocket_smoke_top1_animation.scale = 0.01
-rocket.rocket_smoke_top1_animation.hr_version = nil
-rocket.rocket_smoke_top2_animation.scale = 0.01
-rocket.rocket_smoke_top2_animation.hr_version = nil
-rocket.rocket_smoke_top3_animation.scale = 0.01
-rocket.rocket_smoke_top3_animation.hr_version = nil
-
-local silo = util.table.deepcopy(data.raw["rocket-silo"]["rocket-silo"])
-silo.name = "maraxsis-rocket-silo"
-silo.localised_name = {"entity-name.rocket-silo"}
-silo.localised_description = {"entity-description.rocket-silo"}
-silo.rocket_entity = "maraxsis-rocket-silo-rocket"
-silo.fixed_recipe = "maraxsis-rocket-part"
-silo.hidden_in_factoriopedia = true
-silo.disabled_when_recipe_not_researched = true
-silo.placeable_by = {{item = "rocket-silo", count = 1}}
-silo.flags = {"placeable-player", "player-creation", "not-in-made-in"}
-silo.logistic_trash_inventory_size = 1
-silo.hidden = true
-silo.hidden_in_factoriopedia = true
-
-data:extend { rocket, silo }
+PlanetsLib.assign_rocket_part_recipe(maraxsis_constants.MARAXSIS_SURFACE_NAME,maraxsis_rocket_part.name )

--- a/scripts/project-seadragon.lua
+++ b/scripts/project-seadragon.lua
@@ -1,53 +1,55 @@
--- Adapted from Rubia & Alternative Rocket Sprite Extension.
+-- Now relies on PlanetsLib rocket part recipe assignment.
 
-maraxsis.on_event(maraxsis.events.on_built(), function(event)
-    local entity = event.entity
-    if not entity.valid then return end
-    local surface = entity.surface
-    if surface.name ~= "maraxsis" then return end
+-- -- Adapted from Rubia & Alternative Rocket Sprite Extension.
 
-    local is_ghost = entity.name == "entity-ghost"
-    local type = is_ghost and entity.ghost_type or entity.type
-    if type ~= "rocket-silo" then return end
-    local prototype = is_ghost and entity.ghost_prototype or entity.prototype
-    if not prototype.crafting_categories["rocket-building"] then return end
-    local name = is_ghost and entity.ghost_name or entity.name
-    if name == "maraxsis-rocket-silo" then return end
+-- maraxsis.on_event(maraxsis.events.on_built(), function(event)
+--     local entity = event.entity
+--     if not entity.valid then return end
+--     local surface = entity.surface
+--     if surface.name ~= "maraxsis" then return end
 
-    local new_entity = surface.create_entity {
-        name = is_ghost and "entity-ghost" or "maraxsis-rocket-silo",
-        inner_name = is_ghost and "maraxsis-rocket-silo" or nil,
-        tags = is_ghost and entity.tags or nil,
-        position = entity.position,
-        direction = entity.direction,
-        force = entity.force_index,
-        quality = entity.quality,
-        health = entity.health,
-        raise_built = true,
-        player = event.player_index and game.get_player(event.player_index) or nil,
-    }
-    assert(new_entity and new_entity.valid)
-    new_entity.mirroring = entity.mirroring
-    new_entity.copy_settings(entity)
+--     local is_ghost = entity.name == "entity-ghost"
+--     local type = is_ghost and entity.ghost_type or entity.type
+--     if type ~= "rocket-silo" then return end
+--     local prototype = is_ghost and entity.ghost_prototype or entity.prototype
+--     if not prototype.crafting_categories["rocket-building"] then return end
+--     local name = is_ghost and entity.ghost_name or entity.name
+--     if name == "maraxsis-rocket-silo" then return end
 
-    --Transfer modules, but only if the entity has them!
-    local module_inventory = entity.get_module_inventory() 
-    if not is_ghost and module_inventory then
-        local modules = module_inventory.get_contents()
-        for _, item in pairs(modules) do
-            local inserted_count = new_entity.insert(item)
-            if inserted_count < item.count then
-                item.count = item.count - inserted_count
-                surface.spill_item_stack {
-                    position = entity.position,
-                    stack = item,
-                    enable_looted = true,
-                    force = entity.force_index,
-                    allow_belts = false
-                }
-            end
-        end
-    end
+--     local new_entity = surface.create_entity {
+--         name = is_ghost and "entity-ghost" or "maraxsis-rocket-silo",
+--         inner_name = is_ghost and "maraxsis-rocket-silo" or nil,
+--         tags = is_ghost and entity.tags or nil,
+--         position = entity.position,
+--         direction = entity.direction,
+--         force = entity.force_index,
+--         quality = entity.quality,
+--         health = entity.health,
+--         raise_built = true,
+--         player = event.player_index and game.get_player(event.player_index) or nil,
+--     }
+--     assert(new_entity and new_entity.valid)
+--     new_entity.mirroring = entity.mirroring
+--     new_entity.copy_settings(entity)
 
-    entity.destroy()
-end)
+--     --Transfer modules, but only if the entity has them!
+--     local module_inventory = entity.get_module_inventory() 
+--     if not is_ghost and module_inventory then
+--         local modules = module_inventory.get_contents()
+--         for _, item in pairs(modules) do
+--             local inserted_count = new_entity.insert(item)
+--             if inserted_count < item.count then
+--                 item.count = item.count - inserted_count
+--                 surface.spill_item_stack {
+--                     position = entity.position,
+--                     stack = item,
+--                     enable_looted = true,
+--                     force = entity.force_index,
+--                     allow_belts = false
+--                 }
+--             end
+--         end
+--     end
+
+--     entity.destroy()
+-- end)


### PR DESCRIPTION
Thank you for choosing to make PlanetsLib a dependency of Maraxsis! I never expected you to do this, but now that you have, it makes sense to integrate some of PlanetsLib's features into Maraxsis to reduce the chance of script conflicts. This PR replaces Maraxsis' rocket silo scripting with a single line assigning Maraxsis' rocket part to Maraxsis under PlanetsLib's rocket part assignment system. This system is forked from an older version of Maraxsis' rocket part recipe script, but uses a mod-data table to allow multiple planets to use the same script to assign rocket part recipes. It is well-tested with other planet mods such as Muluna, Muria, Rabbasca, and Crucible using it at the moment. I did not notice until after finishing this PR, but this will remove the fish rocket from the game. 

<img width="1530" height="1748" alt="image" src="https://github.com/user-attachments/assets/73f0f3cd-567c-451f-8a87-f268c5743d86" />
