### PR TITLE
compat: Added surface condition to Fish oil rocket part recipe to prevent the recipe from being selectable on planets other than Maraxsis.

### DIFF
--- a/prototypes/technology/hydraulic-science-pack.lua
+++ b/prototypes/technology/hydraulic-science-pack.lua
@@ -100,4 +100,11 @@ data:extend {{
     categories = {"rocket-building"},
     always_show_made_in = true,
     hide_from_player_crafting = true,
+    surface_conditions = {
+        {
+            property = "pressure",
+            min = 200000,
+           
+        }
+    }
 }}


### PR DESCRIPTION
This PR stops rocket silos from having their recipe unlock on placement when detecting that more than one recipe is available for the rocket silo.